### PR TITLE
🦆 Add environment variables for selecting DDNS URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following environment variables are required for running the _web app_ or th
 `MAIL_USER` | _str_ | email client user (for sending emails with the current instance IP)
 `MAIL_APP_PASSWORD` | _str_ | email client user (for sending emails with the current instance IP)
 `MAIL_RECIPIENTS` | _str_ | email recipients as string, separated by `,` (for sending emails with the current instance IP)
+`DUCKDNS_URL` | _str_ | _URL_ used to update dynamic address (with _Duck DNS_)
 
 
 ### 2.3. Install data-lunch CLI

--- a/docker/compose_init.sh
+++ b/docker/compose_init.sh
@@ -4,9 +4,9 @@
     # Before starting set up the dynamic dns
     # First call
     mkdir -p ~/duckdns
-    echo url="https://www.duckdns.org/update?domains=data-lunch&token=8657275c-de2c-494c-a42a-f1a97958571c&ip=" | curl -k -o ~/duckdns/duck.log -K -
+    echo url=${DUCKDNS_URL} | curl -k -o ~/duckdns/duck.log -K -
     # Set the cronjob
-    croncmd='echo url="https://www.duckdns.org/update?domains=data-lunch&token=8657275c-de2c-494c-a42a-f1a97958571c&ip=" | curl -k -o ~/duckdns/duck.log -K -'
+    croncmd="echo url=${DUCKDNS_URL} | curl -k -o ~/duckdns/duck.log -K -"
     cronjob="*/5 * * * * $croncmd"
     ( crontab -l | grep -v -F "$croncmd" || : ; echo "$cronjob" ) | crontab -
 


### PR DESCRIPTION
Add an environment variable (`DUCKDNS_URL`) for passing the _URL_ used by _Duck DNS_ to `compose_init.sh`.