### PR TITLE
🎖️ Fix error in `compose_init.sh` and improve CI pipeline

### DIFF
--- a/.github/workflows/manual_build.yaml
+++ b/.github/workflows/manual_build.yaml
@@ -1,0 +1,43 @@
+# Bump version with Commitizen
+
+name: Manual build
+
+on: 
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Docker image tag'
+        required: true
+        default: 'latest'
+      build_description:
+        description: 'Build description' 
+
+jobs:
+  build_container:
+    needs: merge_back_to_dev
+    name: Build container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print build info
+        run: |
+          echo "Image tag: ${{ github.event.inputs.tag }}"
+          echo "Description: ${{ github.event.inputs.build_description }}" 
+      - name: Checkout 
+        uses: actions/checkout@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./
+          file: ./docker/web/Dockerfile.web
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/data-lunch-app:${{ github.event.inputs.tag }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/data-lunch-app:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/data-lunch-app:buildcache,mode=max

--- a/.github/workflows/release_new_version.yaml
+++ b/.github/workflows/release_new_version.yaml
@@ -64,16 +64,11 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Build and push
         uses: docker/build-push-action@v3
-        env:
-          PANEL_APP: data-lunch-app
-          PANEL_ENV: production
-          PORT: 5000
-          GCLOUD_PROJECT: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
         with:
           context: ./
           file: ./docker/web/Dockerfile.web
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/data-lunch-app:latest
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/data-lunch-app:stable
           cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/data-lunch-app:buildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/data-lunch-app:buildcache,mode=max

--- a/docker/compose_init.sh
+++ b/docker/compose_init.sh
@@ -6,7 +6,7 @@
     mkdir -p ~/duckdns
     echo url=${DUCKDNS_URL} | curl -k -o ~/duckdns/duck.log -K -
     # Set the cronjob
-    croncmd="echo url=${DUCKDNS_URL} | curl -k -o ~/duckdns/duck.log -K -"
+    croncmd="echo url=\"${DUCKDNS_URL}\" | curl -k -o ~/duckdns/duck.log -K -"
     cronjob="*/5 * * * * $croncmd"
     ( crontab -l | grep -v -F "$croncmd" || : ; echo "$cronjob" ) | crontab -
 


### PR DESCRIPTION
Fix an error that prevented the _cronjob_ for _Duck DNS_ from working.

Improve CI pipeline (_GitHub Actions_):

- Improve`release_new_version.yaml`
- Release the version built on `main` branch with the `stable` tag
- Add a _manual build_ dispatchable workflow