### PR TITLE
⏹️ Fix the 'Stop Orders' button behavior

### DIFF
--- a/.github/workflows/release_new_version.yaml
+++ b/.github/workflows/release_new_version.yaml
@@ -22,11 +22,13 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
       - name: Bump and changelog
+        if: contains(github.event.head_commit.message, 'Merge')
         id: cz
         uses: commitizen-tools/commitizen-action@0.15.1
         with:
           github_token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
       - name: Print version
+        if: contains(github.event.head_commit.message, 'Merge')
         run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
   merge_back_to_dev:
     needs: bump_version
@@ -40,10 +42,12 @@ jobs:
           ref: main
           token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
       - name: Set Git config
+        if: contains(github.event.head_commit.message, 'Merge')
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
       - name: Merge master back to dev
+        if: contains(github.event.head_commit.message, 'Merge')
         run: |
           git checkout development
           git merge --no-ff main -m "Merge branch 'main' into development"
@@ -58,13 +62,16 @@ jobs:
         with: 
           ref: main
       - name: Login to DockerHub
+        if: contains(github.event.head_commit.message, 'Merge')
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Set up Docker Buildx
+        if: contains(github.event.head_commit.message, 'Merge')
         uses: docker/setup-buildx-action@v2
       - name: Build and push
+        if: contains(github.event.head_commit.message, 'Merge')
         uses: docker/build-push-action@v3
         with:
           context: ./

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.39.1
+    rev: v2.40.0
     hooks:
       - id: commitizen
         stages: [commit-msg]

--- a/data_lunch_app/__init__.py
+++ b/data_lunch_app/__init__.py
@@ -72,7 +72,7 @@ def create_app(config: DictConfig) -> pn.Template:
     log.info("instantiate Panel app")
 
     # Panel configurations
-    log.debug("set panel config and cache")
+    log.debug("set panel config and flags")
     # Configurations
     pn.config.nthreads = config.panel.nthreads
     pn.config.notifications = True

--- a/data_lunch_app/__init__.py
+++ b/data_lunch_app/__init__.py
@@ -15,7 +15,7 @@ import sqlalchemy
 from omegaconf import DictConfig, open_dict
 
 # Database imports
-from .models import db, create_database
+import models
 from .cloud import download_from_gcloud
 
 # Core imports
@@ -67,7 +67,7 @@ def create_app(config: DictConfig) -> pn.Template:
         log.info("downloading database file from bucket")
         hydra.utils.call(config.db.gcloud_storage.download)
     # Then create tables
-    create_database(config)
+    models.create_database(config)
 
     log.info("instantiate Panel app")
 
@@ -76,9 +76,10 @@ def create_app(config: DictConfig) -> pn.Template:
     # Configurations
     pn.config.nthreads = config.panel.nthreads
     pn.config.notifications = True
-    # Cache for no_more_orders flag
-    if "no_more_orders" not in pn.state.cache:
-        pn.state.cache["no_more_orders"] = False
+    # Set the no_more_orders flag if it is None (not found in flags table)
+    session = models.create_session(config)
+    if models.get_flag(session=session, id="no_more_orders") is None:
+        models.set_flag(session=session, id="no_more_orders", value=False)
 
     # Set action to run when sessions are destroyed
     # If google cloud is configured, download the sqlite database from storage
@@ -148,7 +149,7 @@ def create_app(config: DictConfig) -> pn.Template:
     res_col = pn.Column(sizing_mode="stretch_width")
     # Toggle button that stop orders (used in time column)
     toggle_no_more_order_button = pnw.Toggle(
-        value=pn.state.cache["no_more_orders"],
+        value=models.get_flag(session=session, id="no_more_orders"),
         name="⌛ Stop Orders",
         width=150,
     )
@@ -158,7 +159,10 @@ def create_app(config: DictConfig) -> pn.Template:
     def reload_on_no_more_order(toggle_button):
 
         # Update global variable
-        pn.state.cache["no_more_orders"] = toggle_button
+        session = models.create_session(config)
+        models.set_flag(
+            session=session, id="no_more_orders", value=toggle_button
+        )
 
         # Show "no more order" text
         no_more_order_text.visible = toggle_button
@@ -362,7 +366,10 @@ def create_app(config: DictConfig) -> pn.Template:
 
     # Set components visibility based on no_more_order_button state
     # and reload menu
-    reload_on_no_more_order(pn.state.cache["no_more_orders"])
+    reload_on_no_more_order(
+        models.get_flag(session=session, id="no_more_orders")
+    )
+    session.close()
 
     app.servable()
 

--- a/data_lunch_app/__init__.py
+++ b/data_lunch_app/__init__.py
@@ -15,7 +15,7 @@ import sqlalchemy
 from omegaconf import DictConfig, open_dict
 
 # Database imports
-import models
+from . import models
 from .cloud import download_from_gcloud
 
 # Core imports

--- a/data_lunch_app/cli.py
+++ b/data_lunch_app/cli.py
@@ -3,6 +3,7 @@ import pkg_resources
 from hydra import compose, initialize
 from omegaconf import OmegaConf
 import pandas as pd
+import panel as pn
 from .models import create_database, create_engine
 
 # Import database object
@@ -31,6 +32,24 @@ def cli(ctx):
     initialize(config_path="conf", job_name="data_lunch_cli")
     config = compose(config_name="config")
     ctx.obj = {"config": config}
+
+
+@cli.group()
+@click.pass_obj
+def cache(obj):
+    """Manage cache."""
+
+
+@cache.command("clean")
+@click.confirmation_option()
+@click.pass_obj
+def clean_caches(obj):
+    """Clean caches."""
+
+    # Clear action
+    pn.state.clear_caches()
+
+    click.secho("Caches cleared", fg="green")
 
 
 @cli.group()

--- a/data_lunch_app/core.py
+++ b/data_lunch_app/core.py
@@ -126,9 +126,8 @@ def clean_tables(config: DictConfig):
     session.commit()
     log.info(f"deleted {num_rows_deleted} from table 'users'")
     # Clean flags
-    num_rows_deleted = session.query(models.Flags).delete()
-    session.commit()
-    log.info(f"deleted {num_rows_deleted} from table 'flags'")
+    models.set_flag(session=session, id="no_more_orders", value=False)
+    log.info("reset values in table 'flags'")
 
 
 def build_menu(

--- a/data_lunch_app/core.py
+++ b/data_lunch_app/core.py
@@ -125,6 +125,10 @@ def clean_tables(config: DictConfig):
     num_rows_deleted = session.query(models.Users).delete()
     session.commit()
     log.info(f"deleted {num_rows_deleted} from table 'users'")
+    # Clean flags
+    num_rows_deleted = session.query(models.Flags).delete()
+    session.commit()
+    log.info(f"deleted {num_rows_deleted} from table 'flags'")
 
 
 def build_menu(
@@ -258,13 +262,20 @@ def reload_menu(
     no_more_order: pnw.Toggle,
 ) -> None:
 
+    # Create session
+    session = models.create_session(config)
+
     # Check if someone changed the "no_more_order" toggle
-    if no_more_order.value != pn.state.cache["no_more_orders"]:
+    if no_more_order.value != models.get_flag(
+        session=session, id="no_more_orders"
+    ):
         # The following statement will trigger the toggle callback
         # which will call reload_menu once again
         # This is the reason why this if contains a return (without the return
         # the content will be reloaded twice)
-        no_more_order.value = pn.state.cache["no_more_orders"]
+        no_more_order.value = models.get_flag(
+            session=session, id="no_more_orders"
+        )
 
         return
 
@@ -288,9 +299,6 @@ def reload_menu(
         dataframe_widget.disabled = False
 
     log.debug("menu reloaded")
-
-    # Create session
-    session = models.create_session(config)
 
     # Load results
     df_dict = df_list_by_lunch_time(config)
@@ -444,8 +452,11 @@ def send_order(
     error_message.visible = False
     confirm_message.visible = False
 
+    # Create session
+    session = models.create_session(config)
+
     # Check if the "no more order" toggle button is pressed
-    if pn.state.cache["no_more_orders"]:
+    if models.get_flag(session=session, id="no_more_orders"):
         pn.state.notifications.error(
             "It is not possible to place new orders",
             duration=config.panel.notifications.duration,
@@ -470,7 +481,6 @@ def send_order(
 
     # If username is missing or the order is empty return an error message
     if person.username and not df_order.empty:
-        session = models.create_session(config)
         # Check if the user already placed an order
         if session.query(models.Users).get(person.username):
             pn.state.notifications.warning(
@@ -488,9 +498,9 @@ def send_order(
                     guest=person.guest,
                     note=person.note,
                 )
+                session.add(new_user)
                 # Add orders as long table (one row for each item selected by a user)
                 for index, row in df_order.iterrows():
-                    session.add(new_user)
                     # Order
                     new_order = models.Orders(
                         user=person.username,
@@ -562,8 +572,11 @@ def delete_order(
     error_message.visible = False
     confirm_message.visible = False
 
+    # Create session
+    session = models.create_session(config)
+
     # Check if the "no more order" toggle button is pressed
-    if pn.state.cache["no_more_orders"]:
+    if models.get_flag(session=session, id="no_more_orders"):
         pn.state.notifications.error(
             "It is not possible to delete orders",
             duration=config.panel.notifications.duration,
@@ -583,7 +596,6 @@ def delete_order(
         return
 
     if person.username:
-        session = models.create_session(config)
         # Delete user
         num_rows_deleted_users = (
             session.query(models.Users)

--- a/data_lunch_app/models.py
+++ b/data_lunch_app/models.py
@@ -166,8 +166,8 @@ def get_flag(session: Session, id: str) -> bool | None:
     """Get the value of a flag"""
 
     flag = session.query(Flags).get(id)
-    if flag:
-        value = session.query(Flags).get(id).value
-    else:
+    if flag is None:
         value = None
+    else:
+        value = session.query(Flags).get(id).value
     return value

--- a/data_lunch_app/models.py
+++ b/data_lunch_app/models.py
@@ -112,7 +112,21 @@ class Stats(db):
     )
 
     def __repr__(self):
-        return f"<STAT:{self.id} - HP:{self.hungry_people}>"
+        return f"<STAT:{self.id} - HP:{self.hungry_people} - HG:{self.hungry_guests}>"
+
+
+class Flags(db):
+    __tablename__ = "flags"
+    id = Column(
+        String(50),
+        primary_key=True,
+        nullable=False,
+        sqlite_on_conflict_primary_key="REPLACE",
+    )
+    value = Column(Boolean, nullable=False)
+
+    def __repr__(self):
+        return f"<FLAG:{self.id} - value:{self.value}>"
 
 
 # FUNCTIONS -------------------------------------------------------------------
@@ -133,7 +147,27 @@ def create_session(config: DictConfig) -> Session:
     return session
 
 
-def create_database(config: DictConfig):
+def create_database(config: DictConfig) -> None:
     """Database factory function"""
     engine = create_engine(config)
     db.metadata.create_all(engine)
+
+
+def set_flag(session: Session, id: str, value: bool) -> None:
+    """Set value inside flag table"""
+
+    # Write the selected flag (it will be overwritten if exists)
+    new_flag = Flags(id=id, value=value)
+    session.add(new_flag)
+    session.commit()
+
+
+def get_flag(session: Session, id: str) -> bool | None:
+    """Get the value of a flag"""
+
+    flag = session.query(Flags).get(id)
+    if flag:
+        value = session.query(Flags).get(id).value
+    else:
+        value = None
+    return value


### PR DESCRIPTION
**Fix**
The _Stop Orders_ button used `pn.state.cache` to store a status flag, but its value is not shared among web app instances behind an _Nginx_ server. Activating the _Stop Orders_ button affects only the instance where the command is issued. 
The status flag (named `no_more_orders`) is now stored in a dedicated `flags` table inside the database and shared among every web app instance.

**CI**
Change conditions that trigger the workflow `release_new_version.yaml`.