### PR TITLE
🧊 Improve Tesseract installation process

### DIFF
--- a/docker/web/Dockerfile.web
+++ b/docker/web/Dockerfile.web
@@ -17,14 +17,9 @@ RUN apt update && apt install -y \
   dnsutils \
   gcc \
   libpq-dev \
-  && echo "deb https://notesalexp.org/tesseract-ocr5/$(lsb_release -cs)/ $(lsb_release -cs) main" \
-  | tee /etc/apt/sources.list.d/notesalexp.list > /dev/null \
-  && apt update -oAcquire::AllowInsecureRepositories=true \
-  && apt install -y notesalexp-keyring -oAcquire::AllowInsecureRepositories=true --allow-unauthenticated \
-  && apt update && apt install -y \
   tesseract-ocr \
   tesseract-ocr-ita \
-  && apt-get clean all && rm -rf /var/lib/apt/lists/*
+  && apt clean all && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements
 COPY requirements/requirements.txt /app/requirements/requirements.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,7 +10,7 @@ tenacity==8.2.2
 tqdm==4.65.0
 panel==1.3.6
 sqlalchemy==2.0.23
-psycopg[binary]==3.1.16
+psycopg==3.1.16
 hydra-core==1.3.2
 google-cloud-storage==2.6.0
 pytesseract==0.3.10


### PR DESCRIPTION
**Fix**
Remove reference to unofficial _Tesseract_'s package repo.

**Build**
Align `psycopg` to _Conda_ requirements (do not install `psycopg[binary]`).