### PR TITLE
🗒️ Move notes to order items

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -33,7 +33,7 @@ jobs:
           token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
       - name: Bump and changelog
         id: cz
-        uses: commitizen-tools/commitizen-action@0.20.0
+        uses: commitizen-tools/commitizen-action@0.21.0
         with:
           github_token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           prerelease: "${{ steps.vars.outputs.pre_release }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v3.15.0
+    rev: v3.18.3
     hooks:
       - id: commitizen
         stages: [commit-msg]

--- a/dlunch/__init__.py
+++ b/dlunch/__init__.py
@@ -38,14 +38,15 @@ def create_app(config: DictConfig) -> pn.Template:
         config, add_basic_auth_users=auth.is_basic_auth_active(config=config)
     )
 
+    log.info("initialize support variables")
     # Generate a random password only if requested (check on flag)
-    log.info("set user password")
+    log.debug("config guest user")
     guest_password = core.set_guest_user_password(config)
 
-    log.info("instantiate Panel app")
+    log.info("instantiate app")
 
     # Panel configurations
-    log.debug("set toggle initial state")
+    log.debug("set toggles initial state")
     # Set the no_more_orders flag if it is None (not found in flags table)
     if models.get_flag(config=config, id="no_more_orders") is None:
         models.set_flag(config=config, id="no_more_orders", value=False)

--- a/dlunch/conf/db/postgresql.yaml
+++ b/dlunch/conf/db/postgresql.yaml
@@ -14,7 +14,7 @@ url: ${db.dialect}+${db.driver}://${db.username}:${db.password}@${db.host}:${db.
 # QUERIES
 # Orders
 orders_query: |-
-  SELECT o.user, o.lunch_time, m.item
+  SELECT o.user, o.lunch_time, m.item, o.note
   FROM {schema}.orders o
   LEFT JOIN {schema}.menu m
   ON m.id = o.menu_item_id;

--- a/dlunch/conf/db/sqlite.yaml
+++ b/dlunch/conf/db/sqlite.yaml
@@ -9,7 +9,7 @@ url: ${db.dialect}:///${db.db_path}
 # QUERIES
 # Orders
 orders_query: |-
-  SELECT o.user, o.lunch_time, m.item
+  SELECT o.user, o.lunch_time, m.item, o.note
   FROM orders o
   LEFT JOIN menu m
   ON m.id = o.menu_item_id;

--- a/dlunch/conf/panel/default.yaml
+++ b/dlunch/conf/panel/default.yaml
@@ -56,7 +56,7 @@ additional_items_to_concat:
   - name: Altro
     short_name: Altro
     icon: 🃏
-    description: richieste speciali (da specificare nelle note).
+    description: richieste speciali (da specificare nella colonna note).
 guest_types: # Check also guests icons in panel/gui
   - Edison Guest
   - External Guest

--- a/dlunch/conf/panel/gui/default.yaml
+++ b/dlunch/conf/panel/gui/default.yaml
@@ -100,9 +100,23 @@ takeaway_svg_icon: |-
   </svg>
 takeaway_alert_text_options: 'class="flashing-animation"'
 
+# MENU TABLE
+# Table column alignment
+menu_column_align:
+  id: center
+  item: left
+  order: center
+  note: left
+
 # ORDERS' TABLE
 # Name of the column with total values for orders
 total_column_name: totale
+# Name of the column with notes for orders
+note_column_name: note
+# Note separators
+note_sep:
+  count: " " # Between note and counter
+  element: ", " # Between notes
 
 # CUSTOMIZABLE GRAPHIC OBJECTS
 # Instantiate a panel object to be rendered on app's header

--- a/dlunch/conf/panel/gui/major_release.yaml
+++ b/dlunch/conf/panel/gui/major_release.yaml
@@ -2,7 +2,7 @@ defaults:
   - default
 
 # APP
-version: 2
+version: 3
 title: Data-Lunch&nbsp&nbsp&nbsp V${panel.gui.version}
 
 # CUSTOMIZABLE GRAPHIC OBJECTS

--- a/dlunch/conf/panel/gui/women_day.yaml
+++ b/dlunch/conf/panel/gui/women_day.yaml
@@ -19,7 +19,6 @@ header_object:
   style:
     background-color: white
     border-radius: 2rem
-    padding: 0.3rem
     height: 50px
     width: 50px
     display: inline-block

--- a/dlunch/core.py
+++ b/dlunch/core.py
@@ -346,14 +346,14 @@ def reload_menu(
         )
         # Add order (for selecting items) and note columns
         df["order"] = False
-        df["note"] = ""
+        df[config.panel.gui.note_column_name] = ""
         gi.dataframe.value = df
         gi.dataframe.formatters = {"order": {"type": "tickCross"}}
         gi.dataframe.editors = {
             "id": None,
             "item": None,
             "order": CheckboxEditor(),
-            "note": "input",
+            config.panel.gui.note_column_name: "input",
         }
         gi.dataframe.header_align = OmegaConf.to_container(
             config.panel.gui.menu_column_align, resolve=True
@@ -693,7 +693,9 @@ def send_order(
                             user=username_key_press,
                             lunch_time=person.lunch_time,
                             menu_item_id=row.Index,
-                            note=row.note.lower(),
+                            note=getattr(
+                                row, config.panel.gui.note_column_name
+                            ).lower(),
                         )
                         session.add(new_order)
                         session.commit()

--- a/dlunch/gui.py
+++ b/dlunch/gui.py
@@ -351,7 +351,7 @@ class GraphicInterface:
         # Create dataframe instance
         self.dataframe = pnw.Tabulator(
             name="Order",
-            widths={"note": 180},
+            widths={config.panel.gui.note_column_name: 180},
             selectable=False,
             stylesheets=[config.panel.gui.css_files.custom_tabulator_path],
         )

--- a/dlunch/models.py
+++ b/dlunch/models.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     TypeDecorator,
     Date,
     Boolean,
+    Identity,
     event,
     MetaData,
     delete,
@@ -162,7 +163,7 @@ class Encrypted(TypeDecorator):
 
 class Menu(Data):
     __tablename__ = "menu"
-    id = Column(Integer, primary_key=True)
+    id = Column(Integer, Identity(start=1, cycle=True), primary_key=True)
     item = Column(String(250), unique=False, nullable=False)
     orders = relationship(
         "Orders",
@@ -204,7 +205,7 @@ class Menu(Data):
 
 class Orders(Data):
     __tablename__ = "orders"
-    id = Column(Integer, primary_key=True)
+    id = Column(Integer, Identity(start=1, cycle=True), primary_key=True)
     user = Column(
         String(100),
         ForeignKey("users.id", ondelete="CASCADE"),
@@ -218,7 +219,7 @@ class Orders(Data):
         nullable=False,
     )
     menu_item = relationship("Menu", back_populates="orders")
-    note = relationship("Users", back_populates="orders", uselist=False)
+    note = Column(String(300), unique=False, nullable=True)
 
     @classmethod
     def clear(self, config: DictConfig) -> int:
@@ -266,13 +267,6 @@ class Users(Data):
     )
     takeaway = Column(
         Boolean, nullable=False, default=False, server_default=sql_false()
-    )
-    note = Column(String(500), unique=False, nullable=True)
-    orders = relationship(
-        "Orders",
-        back_populates="note",
-        cascade="all, delete-orphan",
-        passive_deletes=True,
     )
 
     @classmethod

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - setuptools=69.1.1
   - click=8.1.7
   - cryptography=42.0.5
-  - ipykernel=6.29.2
+  - ipykernel=6.29.3
   - ipywidgets=8.1.2
   - openpyxl=3.1.2
   - pandas=2.2.1
@@ -16,7 +16,7 @@ dependencies:
   - tenacity=8.2.3
   - tqdm=4.66.2
   - panel=1.3.8
-  - sqlalchemy=2.0.27
+  - sqlalchemy=2.0.28
   - psycopg=3.1.18
   - sqlite=3.41.2
   - hydra-core=1.3.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 setuptools==69.1.1
 click==8.1.7
 cryptography==42.0.5
-ipykernel==6.29.2
+ipykernel==6.29.3
 ipywidgets==8.1.2
 openpyxl==3.1.2
 pandas==2.2.1
@@ -9,8 +9,8 @@ passlib==1.7.4
 tenacity==8.2.3
 tqdm==4.66.2
 panel==1.3.8
-sqlalchemy==2.0.27
+sqlalchemy==2.0.28
 psycopg==3.1.18
 hydra-core==1.3.2
-google-cloud-storage==2.14.0
+google-cloud-storage==2.15.0
 pytesseract==0.3.10

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,5 +12,5 @@ panel==1.3.8
 sqlalchemy==2.0.28
 psycopg==3.1.18
 hydra-core==1.3.2
-google-cloud-storage==2.15.0
+google-cloud-storage==2.14.0
 pytesseract==0.3.10


### PR DESCRIPTION
**Feat**
- Move notes to menu items
- Remove note from Users table and add it to Orders table
- Adopt Identity columns for ids as best practice for postgresql (ignored by sqlite)
- Handle notes attached to each item of each order and group notes with the same text
- Improve excel file format and columns width
- Improve widgets layout
- Change postgresql and sqlite queries to correctly handle notes
- Add some options related to menu table layout and notes aggregation to panel/gui/default.yaml

**Fix**
Fix errors in panel/gui configuration files for `women_day.yaml` and `major_release.yaml`.

**Style**
Improve logs.

**Build**
- Update dependencies (ipykernel and sqlalchemy).
- Update GitHub Actions (commitizen).

**CI**
Update pre commit hooks (commitizen).

---
**BREAKING CHANGE:**
Move notes from `users` to `orders` table.